### PR TITLE
Refactor and add side-by-side map

### DIFF
--- a/src/rent-vs-mortgage.md
+++ b/src/rent-vs-mortgage.md
@@ -235,7 +235,9 @@ Plot.plot({
 
 </div>
 
-## Detailed Distribution
+## Distribution
+
+### Price distribution
 
 ```js
 // We want to anchor the domains at zero, so need to figure out the maximum ourselves
@@ -303,60 +305,9 @@ Plot.plot({
 
 </div>
 
-## SA2 Details
+### Geographic distribution
 
-The specific details for all SA2s included can be checked below.
-
-```js
-const search = view(Inputs.search(data))
-```
-
-<div class="card" style="padding: 0">
-
-```js
-Inputs.table(search, {
-  width: '100%',
-  height: 800,
-  align: {
-    typical_price: 'right',
-    typical_loan: 'right',
-    monthly_repayment: 'right',
-    typical_monthly_rent: 'right',
-    rent_to_repayment_ratio: 'right',
-    repayment_to_rent_ratio: 'right',
-  },
-  format: {
-    sa2_code: x => `${x}`,
-    sa2_name: titleCaseFormat,
-    sua_name: titleCaseFormat,
-    gcc_name: titleCaseFormat,
-    typical_price: priceFormat,
-    typical_loan: priceFormat,
-    monthly_repayment: priceFormat,
-    typical_monthly_rent: priceFormat,
-    rent_to_repayment_ratio: percentFormat,
-    repayment_to_rent_ratio: percentFormat,
-  },
-  header: {
-    sa2_code: 'SA2 Code',
-    sa2_name: 'SA2 Name',
-    sua_name: 'SUA',
-    gcc_name: 'GCC',
-    property_type: 'Type',
-    typical_price: 'Property $',
-    typical_loan: '80% Loan',
-    monthly_repayment: 'Mortgage',
-    typical_monthly_rent: 'Rent',
-    rent_to_repayment_ratio: 'Rent / Repayment Ratio',
-    repayment_to_rent_ratio: 'Repayment / Rent Ratio',
-  },
-})
-```
-
-</div>
-
-
-## Where are the mortgages relatively "affordable" (closest to rents)?
+Where are the mortgages relatively "affordable" (closest to rents)?
 
 ```js
 const propertyType = view(Inputs.radio(['HOUSE', 'UNIT'], { label: 'Property type', value: 'HOUSE' }))
@@ -523,6 +474,58 @@ Plot.plot({
       fx: () => "HOUSE"
     })))
   ]
+})
+```
+
+</div>
+
+## SA2 Details
+
+The specific details for all SA2s included can be checked below.
+
+```js
+const search = view(Inputs.search(data))
+```
+
+<div class="card" style="padding: 0">
+
+```js
+Inputs.table(search, {
+  width: '100%',
+  height: 800,
+  align: {
+    typical_price: 'right',
+    typical_loan: 'right',
+    monthly_repayment: 'right',
+    typical_monthly_rent: 'right',
+    rent_to_repayment_ratio: 'right',
+    repayment_to_rent_ratio: 'right',
+  },
+  format: {
+    sa2_code: x => `${x}`,
+    sa2_name: titleCaseFormat,
+    sua_name: titleCaseFormat,
+    gcc_name: titleCaseFormat,
+    typical_price: priceFormat,
+    typical_loan: priceFormat,
+    monthly_repayment: priceFormat,
+    typical_monthly_rent: priceFormat,
+    rent_to_repayment_ratio: percentFormat,
+    repayment_to_rent_ratio: percentFormat,
+  },
+  header: {
+    sa2_code: 'SA2 Code',
+    sa2_name: 'SA2 Name',
+    sua_name: 'SUA',
+    gcc_name: 'GCC',
+    property_type: 'Type',
+    typical_price: 'Property $',
+    typical_loan: '80% Loan',
+    monthly_repayment: 'Mortgage',
+    typical_monthly_rent: 'Rent',
+    rent_to_repayment_ratio: 'Rent / Repayment Ratio',
+    repayment_to_rent_ratio: 'Repayment / Rent Ratio',
+  },
 })
 ```
 

--- a/src/rent-vs-mortgage.md
+++ b/src/rent-vs-mortgage.md
@@ -427,7 +427,14 @@ const deckInstance = new DeckGL({
     const properties = point?.object?.properties
     if (!properties) return
 
-    return `${properties.REGION_NAME}\nMortgage ${percentFormat(properties.repayment_to_rent_ratio)} of Rent`
+    return {
+      html: [
+        `<h2>${properties.REGION_NAME}</h2>`,
+        `<b>Mortgage</b> ${percentFormat(properties.repayment_to_rent_ratio)} of Rent<br>`,
+        `<b>Rent</b> ${priceFormat(properties.typical_monthly_rent)}<br>`,
+        `<b>Mortgage</b> ${priceFormat(properties.monthly_repayment)}<br>`,
+      ].join('\n'),
+    }
   },
 })
 
@@ -442,6 +449,25 @@ invalidation.then(() => {
 <div class='card'>
 
 ```js
+  const tooltip = f => [
+    f.properties.REGION_NAME,
+    `Mortgage ${percentFormat(f.properties.repayment_to_rent_ratio)} of Rent`,
+    `Rent ${priceFormat(f.properties.typical_monthly_rent)}`,
+    `Mortgage ${priceFormat(f.properties.monthly_repayment)}`
+  ].join('\n')
+  const tip = (json, type) => Plot.tip(json.features, Plot.pointer(Plot.geoCentroid({
+    title: tooltip,
+    fx: () => type,
+  })))
+  const fill = (json, type) => Plot.geo(json, {
+    fill: d => d.properties.repayment_to_rent_ratio,
+    stroke: 'black',
+    strokeWidth: 0.3,
+    fx: () => type,
+  })
+```
+  
+```js
 Plot.plot({
   aspectRatio: 1,
   width: 1200,
@@ -451,26 +477,10 @@ Plot.plot({
     label: 'Repayment to rent ratio',
   },
   marks: [
-    Plot.geo(melbourneUnits, {
-      fill: d => d.properties.repayment_to_rent_ratio,
-      stroke: 'black',
-      strokeWidth: 0.3,
-      fx: () => "UNIT"
-    }),
-    Plot.tip(melbourneUnits.features, Plot.pointer(Plot.geoCentroid({
-      title: (f) => `${f.properties.REGION_NAME}\nMortgage ${percentFormat(f.properties.repayment_to_rent_ratio)} of Rent`,
-      fx: () => "UNIT"
-    }))),
-    Plot.geo(melbourneHouses, {
-      fill: d => d.properties.repayment_to_rent_ratio,
-      stroke: 'black',
-      strokeWidth: 0.3,
-      fx: () => "HOUSE"
-    }),
-    Plot.tip(melbourneHouses.features, Plot.pointer(Plot.geoCentroid({
-      title: (f) => `${f.properties.REGION_NAME}\nMortgage ${percentFormat(f.properties.repayment_to_rent_ratio)} of Rent`,
-      fx: () => "HOUSE"
-    })))
+    fill(melbourneUnits, 'UNIT'),
+    tip(melbourneUnits, 'UNIT'),
+    fill(melbourneHouses, 'HOUSE'),
+    tip(melbourneHouses, 'HOUSE'),
   ]
 })
 ```

--- a/src/rent-vs-mortgage.md
+++ b/src/rent-vs-mortgage.md
@@ -387,11 +387,12 @@ const joinDataIntoGeojson = (propertyType) => {
 const melbourneUnits = joinDataIntoGeojson('UNIT')
 const melbourneHouses = joinDataIntoGeojson('HOUSE')
 
+const melbourneWithChosenPropertyType = propertyType === 'UNIT' ? melbourneUnits : melbourneHouses
 const domain = rangeType === 'FIXED' ? FIXED_DOMAIN : undefined
 
 const deckColours = Plot.plot({
   color: { domain },
-  marks: [Plot.dot(dataArray.filter(d => d.property_type), { fill: 'repayment_to_rent_ratio' })],
+  marks: [Plot.geo(melbourneWithChosenPropertyType, { fill: d => d.properties.repayment_to_rent_ratio })],
 }).scale('color')
 
 const plotRatioLegend = Plot.legend({
@@ -460,7 +461,7 @@ const deckInstance = new DeckGL({
   layers: [
     new GeoJsonLayer({
       id: 'sa2s',
-      data:  propertyType === 'UNIT' ? melbourneUnits : melbourneHouses,
+      data: melbourneWithChosenPropertyType,
       pickable: true,
       getFillColor: (f) => {
         console.log(f)

--- a/src/rent-vs-mortgage.md
+++ b/src/rent-vs-mortgage.md
@@ -428,12 +428,11 @@ const deckInstance = new DeckGL({
     if (!properties) return
 
     return {
-      html: [
-        `<h2>${properties.REGION_NAME}</h2>`,
-        `<b>Mortgage</b> ${percentFormat(properties.repayment_to_rent_ratio)} of Rent<br>`,
-        `<b>Rent</b> ${priceFormat(properties.typical_monthly_rent)}<br>`,
-        `<b>Mortgage</b> ${priceFormat(properties.monthly_repayment)}<br>`,
-      ].join('\n'),
+      html:
+        `<h2>${properties.REGION_NAME}</h2>
+        <b>Mortgage</b> ${percentFormat(properties.repayment_to_rent_ratio)} of Rent<br>
+        <b>Rent</b> ${priceFormat(properties.typical_monthly_rent)}<br>
+        <b>Mortgage</b> ${priceFormat(properties.monthly_repayment)}<br>`
     }
   },
 })
@@ -449,26 +448,26 @@ invalidation.then(() => {
 <div class='card'>
 
 ```js
-  const tooltip = f => [
-    f.properties.REGION_NAME,
-    `Mortgage ${percentFormat(f.properties.repayment_to_rent_ratio)} of Rent`,
-    `Rent ${priceFormat(f.properties.typical_monthly_rent)}`,
-    `Mortgage ${priceFormat(f.properties.monthly_repayment)}`
-  ].join('\n')
-  const tip = (json, type) => Plot.tip(json.features, Plot.pointer(Plot.geoCentroid({
-    title: tooltip,
-    fx: () => type,
-  })))
-  const fill = (json, type) => Plot.geo(json, {
-    fill: d => d.properties.repayment_to_rent_ratio,
-    stroke: 'black',
-    strokeWidth: 0.3,
-    fx: () => type,
-  })
-```
-  
-```js
-Plot.plot({
+const tip = (json, type) => 
+  Plot.tip(json.features, 
+    Plot.pointer(
+      Plot.geoCentroid({
+        fx: () => type,
+        title: f =>
+`${f.properties.REGION_NAME}
+Mortgage ${percentFormat(f.properties.repayment_to_rent_ratio)} of Rent
+Rent ${priceFormat(f.properties.typical_monthly_rent)}
+Mortgage ${priceFormat(f.properties.monthly_repayment)}`
+})))
+
+const geo = (json, type) => Plot.geo(json, {
+  fill: d => d.properties.repayment_to_rent_ratio,
+  stroke: 'black',
+  strokeWidth: 0.3,
+  fx: () => type,
+})
+
+view(Plot.plot({
   aspectRatio: 1,
   width: 1200,
   color: {
@@ -477,12 +476,12 @@ Plot.plot({
     label: 'Repayment to rent ratio',
   },
   marks: [
-    fill(melbourneUnits, 'UNIT'),
+    geo(melbourneUnits, 'UNIT'),
     tip(melbourneUnits, 'UNIT'),
-    fill(melbourneHouses, 'HOUSE'),
+    geo(melbourneHouses, 'HOUSE'),
     tip(melbourneHouses, 'HOUSE'),
   ]
-})
+}))
 ```
 
 </div>


### PR DESCRIPTION
1. I did some refactoring so that we don't have to do joins in `fill` and `tooltip` methods
2. I thought it would be nice to have a nice "printable" comparison. We lose the dynamic color domain for the 2D variant in exchange for better "AFR-ability"

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/c9a2438e-fb35-44ac-a035-56b31825d9f1">
